### PR TITLE
Modify the k factor in ELO calculation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,13 +71,13 @@ int main()
 
 	bot.on_ready([&](const dpp::ready_t &) {
 		// Clear legacy guild-only commands
-		// bot.global_bulk_command_create({}); // for guild test
-		bot.guild_bulk_command_create({}, guild_id);
+		// bot.global_bulk_command_create({}); // for guild test, clear global command
+		// bot.guild_bulk_command_create({}, guild_id); // clear guild command
 
 		// Register GLOBAL commands (visible in every guild the bot is in).
 		auto cmds = command_handler::commands(bot.me.id);
-		// bot.guild_bulk_command_create(cmds, guild_id); // for guild test
-		bot.global_bulk_command_create(cmds);
+		// bot.guild_bulk_command_create(cmds, guild_id); // for guild test, add guild command
+		bot.global_bulk_command_create(cmds); // add global command
 	});
 
 	bot.on_log(dpp::utility::cout_logger());


### PR DESCRIPTION
Since Elo was originally designed for one-on-one matches, the score adjustment per game is a fixed k. In the current implementation, this k is divided among all members of a team, so each player only gains a very small amount.

This commit changes k into a value that scales with the number of players instead of being fixed, in order to better balance team sizes.

Close #3 